### PR TITLE
Fix memory leaks on allocation of SWIG wrappers.

### DIFF
--- a/recordtrie.go
+++ b/recordtrie.go
@@ -31,14 +31,13 @@ const KV_SEPARATOR = "\xFF"
 
 // Create a new RecordTrie from a list of Records
 func New(records []Record) *RecordTrie {
-	t := marisa.NewTrie()
-	runtime.SetFinalizer(&t, func(t *marisa.Trie) {
-		marisa.DeleteTrie(*t)
-	})
-	
 	r := &RecordTrie{
-		t: t,
+		t: marisa.NewTrie(),
 	}
+	runtime.SetFinalizer(r, func(r *RecordTrie) {
+		marisa.DeleteTrie(r.t)
+	})
+
 	r.build(records)
 
 	return r

--- a/recordtrie.go
+++ b/recordtrie.go
@@ -51,14 +51,13 @@ func NewFromFile(path string) (r *RecordTrie, err error) {
 		}
 	}()
 
-	t := marisa.NewTrie()
-	runtime.SetFinalizer(&t, func(t *marisa.Trie) {
-		marisa.DeleteTrie(*t)
+	r = &RecordTrie{
+		t: marisa.NewTrie(),
+	}
+	runtime.SetFinalizer(r, func(r *RecordTrie) {
+		marisa.DeleteTrie(r.t)
 	})
 
-	r = &RecordTrie{
-		t: t,
-	}
 	r.t.Mmap(path)
 
 	return


### PR DESCRIPTION
- Add finalizers for all SWIG allocations using New*().
- Finalizer explicitly calls Delete*() on the allocated objects when their Go-side objects are collected.
